### PR TITLE
Set paper trading config for SOL/USDC

### DIFF
--- a/config/live_sol_only.yaml
+++ b/config/live_sol_only.yaml
@@ -1,4 +1,5 @@
-mode: live
+mode: paper
+pair: SOL/USDC
 paper: true
 timeframe: 1h
 poll_seconds: 60
@@ -38,4 +39,4 @@ strategy_params:
 
 execution:
   venue: sol_jupiter
-  slippage_bps: 40
+  slippage_bps: 50


### PR DESCRIPTION
## Summary
- switch default config to paper trading mode with SOL/USDC pair
- raise Jupiter executor slippage to 50 bps

## Testing
- `python -m pip install --upgrade pip` *(failed: Tunnel connection failed 403)*
- `pip install -r requirements.txt` *(failed: Could not find a version that satisfies the requirement pandas)*
- `python -m bot.live.run_jupiter --config config/live_sol_only.yaml` *(failed: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6898d256e6f88327b4f6d865f0bee993